### PR TITLE
Add lsm6dsv320x-pid submodule to lib root (pair w/ IMU r3)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "Drivers/STM32H7xx_HAL_Driver"]
 	path = Drivers/STM32H7xx_HAL_Driver
 	url = https://github.com/STMicroelectronics/stm32h7xx-hal-driver.git
+[submodule "lsm6dsv320x-pid"]
+	path = lsm6dsv320x-pid
+	url = https://github.com/STMicroelectronics/lsm6dsv320x-pid.git

--- a/NOTICE
+++ b/NOTICE
@@ -5,3 +5,5 @@ STM32H7xx_HAL_Driver (Drivers/STM32H7xx_HAL_Driver): Copyright (c) 2017 STMicroe
 CMSIS (Drivers/CMSIS): Copyright (c) 2009-2019 Arm Limited. Apache-2.0 License. www.apache.org/licenses/LICENSE-2.0
 
 STM32_USB_Device_Library: Copyright (c) STMicroelectronics. SLA0044 Rev5/February 2018. Full license text is provided with the library in question.
+
+lsm6dsv320x-pid (lib/lsm6dsv320x-pid): Copyright (c) STMicroelectronics. BSD-3-Clause License. https://opensource.org/licenses/BSD-3-Clause

--- a/sdr_pin_defines_A0010.h
+++ b/sdr_pin_defines_A0010.h
@@ -65,6 +65,8 @@ Includes
 #define IMU_INT1_PIN            GPIO_PIN_4
 #define IMU_INT2_PIN            GPIO_PIN_5
 
+#define IMU_INT1_EXTI_IRQn      EXTI4_IRQn
+
 /* USB */
 #define USB_DETECT_PIN          GPIO_PIN_13
 #define USB_OTG_DP_PIN          GPIO_PIN_12


### PR DESCRIPTION
## Description
This PR adds the STMicroelectronics driver for the LSM6DSV320X (lsm6dsv320x-pid) as a git submodule under the library root directory (/lib).

This dependency provides the low-level register maps and driver context APIs utilized by the new imu_lsm.c/h implementation.

### Issue Link
Child PR, Parent: ![Parent_Issue](https://github.com/SunDevilRocketry/driver/pull/28)

### Testing
- [ ] Passes existing unit tests
- [ ] Unit tests modified (link the test changes as a child PR)
- [ ] Integration test performed

Attach any test artifacts here, if relevant.

### Other
Leave any additional notes here

## Reviewer Checklist

### Standards
- [ ] Follows FCF Architectural Standards
- [ ] Follows SDR Coding Standards
- [ ] Code complexity/function Size is minimized
- [ ] Code is testable
- [ ] Code is readable and commented properly
- [ ] License terms are respected

### Error Handling
- [ ] Potentially unsafe functions return a status code
- [ ] Error returns properly handled

### Memory
- [ ] Stack allocated memory is scoped correctly
- [ ] Heap allocated memory is avoided
- [ ] Globally allocated memory is minimized except when necessary
- [ ] Pointers are used correctly
- [ ] Concurrency has been considered

### Performance
- [ ] Rate limiters are respected
- [ ] Busy waiting is avoided
- [ ] "Delay" calls are not used in performance sensitive code